### PR TITLE
Add "result" type for nonthrowing error handling

### DIFF
--- a/source/common/cppex/CMakeLists.txt
+++ b/source/common/cppex/CMakeLists.txt
@@ -5,14 +5,16 @@ set(TARGET_NAME common_cppex)
 add_library(${TARGET_NAME} STATIC 
     src/iterator_traits.cpp
     src/scope_exit.cpp
-    src/unused.cpp)
+    src/unused.cpp
+    src/result.cpp)
 add_dependencies(${TARGET_NAME} clang-format)
 
 add_executable(${TARGET_NAME}_test 
     test/main.cpp
     test/iterator_traits.t.cpp
     test/scope_exit.t.cpp
-    test/unused.t.cpp)
+    test/unused.t.cpp
+    test/result.t.cpp)
 target_link_libraries(
     ${TARGET_NAME}_test
     PRIVATE

--- a/source/common/cppex/CMakeLists.txt
+++ b/source/common/cppex/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${TARGET_NAME} STATIC
     src/iterator_traits.cpp
     src/scope_exit.cpp
     src/unused.cpp
+    src/always_false.cpp
     src/result.cpp)
 add_dependencies(${TARGET_NAME} clang-format)
 
@@ -14,6 +15,7 @@ add_executable(${TARGET_NAME}_test
     test/iterator_traits.t.cpp
     test/scope_exit.t.cpp
     test/unused.t.cpp
+    test/always_false.t.cpp
     test/result.t.cpp)
 target_link_libraries(
     ${TARGET_NAME}_test

--- a/source/common/cppex/include/always_false.h
+++ b/source/common/cppex/include/always_false.h
@@ -1,0 +1,10 @@
+#ifndef MELINDA_COMMON_CPPEX_ALWAYS_FALSE_INCLUDED
+#define MELINDA_COMMON_CPPEX_ALWAYS_FALSE_INCLUDED
+
+namespace mel::cppex
+{
+    template<class>
+    inline constexpr bool always_false_v = false;
+}
+
+#endif

--- a/source/common/cppex/include/result.h
+++ b/source/common/cppex/include/result.h
@@ -1,0 +1,47 @@
+#ifndef MELINDA_COMMON_CPPEX_RESULT_INCLUDED
+#define MELINDA_COMMON_CPPEX_RESULT_INCLUDED
+
+#include <concepts>
+#include <system_error>
+#include <type_traits>
+#include <variant>
+
+namespace mel::cppex
+{
+    template<typename T>
+    concept is_result_value =
+        !std::disjunction_v<std::is_convertible<T, std::error_code>,
+            std::is_convertible<T, std::error_condition>>;
+
+    template<typename T>
+    requires(is_result_value<T>) class result final
+    {
+    public: // Construction
+        template<typename... Args>
+        result(Args&&... value) requires(std::constructible_from<T, Args...>)
+            : value_(std::forward<Args>(value)...)
+        {
+        }
+
+        explicit result(std::error_code error) noexcept { }
+
+        result(result const& other) = default;
+
+        result(result&& other) noexcept = default;
+
+    public: // Operators
+        result& operator=(result const& other);
+
+        result& operator=(result&& other) noexcept;
+
+        explicit operator bool() noexcept { return value_.index() == 0; }
+
+    public: // Destruction
+        ~result() noexcept = default;
+
+    public: // Data
+        std::variant<T, std::error_code> value_;
+    };
+} // namespace mel::cppex
+
+#endif

--- a/source/common/cppex/src/always_false.cpp
+++ b/source/common/cppex/src/always_false.cpp
@@ -1,0 +1,1 @@
+#include "../include/always_false.h"

--- a/source/common/cppex/src/result.cpp
+++ b/source/common/cppex/src/result.cpp
@@ -1,0 +1,1 @@
+#include "../include/result.h"

--- a/source/common/cppex/test/always_false.t.cpp
+++ b/source/common/cppex/test/always_false.t.cpp
@@ -1,0 +1,2 @@
+#include "../include/always_false.h"
+#include "catch2/catch.hpp"

--- a/source/common/cppex/test/result.t.cpp
+++ b/source/common/cppex/test/result.t.cpp
@@ -1,0 +1,23 @@
+#include "../include/result.h"
+#include "catch2/catch.hpp"
+
+TEST_CASE("Result constructed from a value is considered not to be an error")
+{
+    mel::cppex::result<int> r = mel::cppex::result<int>(1);
+    REQUIRE(static_cast<bool>(r));
+}
+
+TEST_CASE(
+    "Result constructed from a std::error_code is considered to be an error")
+{
+    mel::cppex::result<int> r =
+        mel::cppex::result<int>(std::make_error_code(std::errc::bad_address));
+    REQUIRE(static_cast<bool>(r));
+}
+
+TEST_CASE(
+    "std::error_condition and std::error_code are not allowed as values of result")
+{
+    static_assert(!mel::cppex::is_result_value<std::error_code>);
+    static_assert(!mel::cppex::is_result_value<std::error_condition>);
+}

--- a/source/common/cppex/test/result.t.cpp
+++ b/source/common/cppex/test/result.t.cpp
@@ -18,6 +18,6 @@ TEST_CASE(
 TEST_CASE(
     "std::error_condition and std::error_code are not allowed as values of result")
 {
-    static_assert(!mel::cppex::is_result_value<std::error_code>);
-    static_assert(!mel::cppex::is_result_value<std::error_condition>);
+    static_assert(!mel::cppex::detail::is_result_value<std::error_code>);
+    static_assert(!mel::cppex::detail::is_result_value<std::error_condition>);
 }

--- a/source/common/cppex/test/result.t.cpp
+++ b/source/common/cppex/test/result.t.cpp
@@ -1,23 +1,139 @@
 #include "../include/result.h"
 #include "catch2/catch.hpp"
 
-TEST_CASE("Result constructed from a value is considered not to be an error")
+#include <string>
+
+TEST_CASE("result constructed from a value is considered not to be an error")
 {
-    mel::cppex::result<int> r = mel::cppex::result<int>(1);
+    mel::cppex::result<int> const r = mel::cppex::result<int>(1);
     REQUIRE(static_cast<bool>(r));
 }
 
 TEST_CASE(
-    "Result constructed from a std::error_code is considered to be an error")
+    "result constructed from a std::error_code is considered to be an error")
 {
-    mel::cppex::result<int> r =
+    mel::cppex::result<int> const r =
         mel::cppex::result<int>(std::make_error_code(std::errc::bad_address));
-    REQUIRE(static_cast<bool>(r));
+    REQUIRE(!static_cast<bool>(r));
 }
 
 TEST_CASE(
     "std::error_condition and std::error_code are not allowed as values of result")
 {
-    static_assert(!mel::cppex::detail::is_result_value<std::error_code>);
-    static_assert(!mel::cppex::detail::is_result_value<std::error_condition>);
+    static_assert(!mel::cppex::detail::result_value<std::error_code>);
+    static_assert(!mel::cppex::detail::result_value<std::error_condition>);
+}
+
+TEST_CASE(
+    "result can be constructed by forwarding the values to a T constructor")
+{
+    struct test_class final
+    {
+        test_class(int trivial, std::string&& str)
+            : trivial_(trivial)
+            , str_(std::move(str)) {};
+
+        int trivial_;
+        std::string str_;
+    };
+
+    mel::cppex::result<test_class> const result =
+        mel::cppex::result<test_class>(1, "test");
+    REQUIRE(static_cast<bool>(result));
+
+    test_class const& value = static_cast<test_class const&>(result);
+    REQUIRE(value.trivial_ == 1);
+    REQUIRE(value.str_ == "test");
+}
+
+TEST_CASE("Special member functions are propagated from containing type")
+{
+    struct default_constructible final
+    {
+        default_constructible() = default;
+        default_constructible(default_constructible const&) = delete;
+        default_constructible(default_constructible&&) noexcept = delete;
+        default_constructible& operator=(default_constructible const&) = delete;
+        default_constructible& operator=(
+            default_constructible&&) noexcept = delete;
+        ~default_constructible() noexcept = default;
+    };
+
+    static_assert(std::is_default_constructible_v<
+        mel::cppex::result<default_constructible>>);
+    static_assert(!std::is_copy_constructible_v<
+                  mel::cppex::result<default_constructible>>);
+    static_assert(!std::is_move_constructible_v<
+                  mel::cppex::result<default_constructible>>);
+    static_assert(
+        !std::is_copy_assignable_v<mel::cppex::result<default_constructible>>);
+    static_assert(
+        !std::is_move_assignable_v<mel::cppex::result<default_constructible>>);
+
+    struct copyable final
+    {
+        copyable() = delete;
+        copyable(copyable const&) = default;
+        copyable(copyable&&) noexcept = delete;
+        copyable& operator=(copyable const&) = default;
+        copyable& operator=(copyable&&) noexcept = delete;
+        ~copyable() noexcept = default;
+    };
+
+    // std::is_move_constructible/assignable bind to a const& overload
+    // if the type isn't movable, so it can't be checked?
+    static_assert(
+        !std::is_default_constructible_v<mel::cppex::result<copyable>>);
+    static_assert(std::is_copy_constructible_v<mel::cppex::result<copyable>>);
+    // static_assert(!std::is_move_constructible_v<mel::cppex::result<copyable>>);
+    static_assert(std::is_copy_assignable_v<mel::cppex::result<copyable>>);
+    // static_assert(!std::is_move_assignable_v<mel::cppex::result<copyable>>);
+
+    struct moveable final
+    {
+        moveable() = delete;
+        moveable(moveable const&) = delete;
+        moveable(moveable&&) noexcept = default;
+        moveable& operator=(moveable const&) = delete;
+        moveable& operator=(moveable&&) = default;
+        ~moveable() noexcept = default;
+    };
+
+    static_assert(
+        !std::is_default_constructible_v<mel::cppex::result<moveable>>);
+    static_assert(!std::is_copy_constructible_v<mel::cppex::result<moveable>>);
+    static_assert(std::is_move_constructible_v<mel::cppex::result<moveable>>);
+    static_assert(!std::is_copy_assignable_v<mel::cppex::result<moveable>>);
+    static_assert(std::is_move_assignable_v<mel::cppex::result<moveable>>);
+}
+
+TEST_CASE("result::map preserves the error")
+{
+    mel::cppex::result<int> const result =
+        mel::cppex::result<int>(std::make_error_code(std::errc::bad_address));
+
+    mel::cppex::result<std::string> mapped =
+        result.map([](int v) { return std::to_string(v); });
+    REQUIRE(static_cast<std::error_code>(mapped) == std::errc::bad_address);
+}
+
+TEST_CASE("result::map_or returns default value in error case")
+{
+    mel::cppex::result<int> const result =
+        mel::cppex::result<int>(std::make_error_code(std::errc::bad_address));
+
+    long const value = result.map_or([](int v) { return long(v); }, 5);
+    REQUIRE(value == 5);
+}
+
+TEST_CASE("result::map_or_else invokes correct callback")
+{
+    mel::cppex::result<int> value = mel::cppex::result<int>(5);
+    mel::cppex::result<int> error =
+        mel::cppex::result<int>(std::make_error_code(std::errc::bad_address));
+
+    auto value_callback = [](int) { return 3; };
+    auto error_callback = [](std::error_code) { return 5; };
+    REQUIRE(value.map_or_else(value_callback, error_callback) == 3);
+    REQUIRE(error.map_or_else(value_callback, error_callback) == 5);
 }


### PR DESCRIPTION
- Add implementation of result type loosely based on std::result from Rust / expected-lite library