### PR TITLE
Switch to header only boost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,16 @@ executors:
 
 workflows:
   version: 2
-# GCC:
-#   jobs:
-#     - build_with_gcc:
-#         context:
-#           - docker-hub-creds
-#     - test:
-#         context:
-#           - docker-hub-creds
-#         requires:
-#           - build_with_gcc
+ GCC:
+   jobs:
+     - build_with_gcc:
+         context:
+           - docker-hub-creds
+     - test:
+         context:
+           - docker-hub-creds
+         requires:
+           - build_with_gcc
   Clang:
     jobs:
       - build_with_clang:
@@ -40,8 +40,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Temporary workaround for GCC-11
+          command: conan config init && sed -i 's/\"4.8\", \"4.9\"/\"4.8\", \"4.9\", \"11\", \"11.1\"/' ~/.conan/settings.yml
+      - run:
           name: Build sources
-          command: ./scripts/build.sh -c RelWithDebInfo
+          command: ./scripts/build.sh -c Release
       - persist_to_workspace:
           root: .
           paths:
@@ -57,7 +60,7 @@ jobs:
       - checkout
       - run:
           name: Build sources
-          command: ./scripts/build.sh -c RelWithDebInfo
+          command: ./scripts/build.sh -c Release
       - persist_to_workspace:
           root: .
           paths: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,16 @@ executors:
 
 workflows:
   version: 2
- GCC:
-   jobs:
-     - build_with_gcc:
-         context:
-           - docker-hub-creds
-     - test:
-         context:
-           - docker-hub-creds
-         requires:
-           - build_with_gcc
+  GCC:
+    jobs:
+      - build_with_gcc:
+          context:
+            - docker-hub-creds
+      - test:
+          context:
+            - docker-hub-creds
+          requires:
+            - build_with_gcc
   Clang:
     jobs:
       - build_with_clang:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,6 @@ include(cmake/dependencies.cmake)
 
 set(FLATBUFFERS_FLATC_EXECUTABLE ${CONAN_BIN_DIRS_FLATC}/flatc)
 
-enable_testing()
-
-add_compile_options(-W -Wall -Wextra -pedantic)
-
 if (NOT SETUP_DEPENDENCIES_ONLY)
     add_subdirectory(source)
 endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -17,6 +17,8 @@ conan_cmake_run(
         cppzmq/4.7.1
         flatc/1.12.0
         flatbuffers/1.12.0
+    OPTIONS
+        boost:header_only=True
     BASIC_SETUP
         CMAKE_TARGETS
     BUILD

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,3 +1,7 @@
+enable_testing()
+
+add_compile_options(-W -Wall -Wextra -pedantic)
+
 add_subdirectory(network)
 add_subdirectory(common)
 add_subdirectory(client)


### PR DESCRIPTION
- CircleCI switched to use Release configuration instead of RelWithDebInfo
- Switch to header-only boost to avoid compiling it on CircleCI
