### PR TITLE
Add option to specify location of data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Melinda - Relational Database Management System
 * Run scripts/build.sh
   * Script supports optional configuration parameter (-c) with options Debug, RelWithDebInfo, Release
 
+# Testing
+* Run scripts/test.sh
+  * Script supports optional testing directory parameter (-d), specify the filesystem location used for tests, defaults to value of MELINDA\_TEST\_DIRECTORY or /tmp if not set

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,7 +1,6 @@
 include(${PROJECT_SOURCE_DIR}/cmake/conan.cmake)
 
 # Conan and dependencies configuration
-
 conan_cmake_configure(
     REQUIRES
         catch2/3.1.0
@@ -13,7 +12,37 @@ conan_cmake_configure(
         zlib/1.2.12
     OPTIONS
         zeromq:encryption=tweetnacl
+        boost:without_atomic=True
+        boost:without_chrono=True
+        boost:without_container=True
+        boost:without_context=True
+        boost:without_contract=True
+        boost:without_coroutine=True
+        boost:without_date_time=True
+        boost:without_exception=True
+        boost:without_fiber=True
+        boost:without_filesystem=True
+        boost:without_graph=True
+        boost:without_graph_parallel=True
+        boost:without_iostreams=True
+        boost:without_json=True
+        boost:without_locale=True
+        boost:without_log=True
+        boost:without_math=True
+        boost:without_mpi=True
+        boost:without_nowide=True
+        boost:without_program_options=False
+        boost:without_python=True
+        boost:without_random=True
+        boost:without_regex=True
+        boost:without_serialization=True
+        boost:without_stacktrace=True
+        boost:without_system=True
         boost:without_test=True
+        boost:without_thread=True
+        boost:without_timer=True
+        boost:without_type_erasure=True
+        boost:without_wave=True
     GENERATORS
         cmake_find_package
 )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 CONFIGURATION=Debug
 
-optstring=":c"
+optstring="c:"
 
 while getopts ${optstring} option
 do

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
+TEST_DIRECTORY=${MELINDA_TEST_DIRECTORY:-/tmp}
+
+optstring="d:"
+
 if [ ! -d build ]
 then
     echo ERROR: Build directory doesn\'t exist.
     exit 1
 fi
 
-cd build && ctest -V -W && cd ..
+while getopts ${optstring} option
+do
+    case "${option}"
+    in
+        d) TEST_DIRECTORY=${OPTARG};;
+    esac
+done
+
+echo "TD = ${TEST_DIRECTORY}"
+
+cd build && \
+    MELINDA_TEST_DIRECTORY=${TEST_DIRECTORY} ctest -V -W && \
+    cd ..
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,8 +18,6 @@ do
     esac
 done
 
-echo "TD = ${TEST_DIRECTORY}"
-
 cd build && \
     MELINDA_TEST_DIRECTORY=${TEST_DIRECTORY} ctest -V -W && \
     cd ..

--- a/source/mdb/mdbsql/CMakeLists.txt
+++ b/source/mdb/mdbsql/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(${TARGET_NAME}
 target_include_directories(${TARGET_NAME} PUBLIC include)
 
 add_executable(${TARGET_NAME}_test
+    test/mdbsql.t.cpp
     test/mdbsql_engine.t.cpp
     test/mdbsql_grammar.t.cpp
     test/mdbsql_statement.t.cpp
@@ -30,5 +31,6 @@ target_link_libraries(
         Catch2::Catch2WithMain
         project-options
 )
+target_include_directories(${TARGET_NAME}_test PRIVATE test)
 add_dependencies(${TARGET_NAME}_test clang-format)
 catch_discover_tests(${TARGET_NAME}_test)

--- a/source/mdb/mdbsql/include/mdbsql_engine.h
+++ b/source/mdb/mdbsql/include/mdbsql_engine.h
@@ -1,6 +1,7 @@
 #ifndef MELINDA_MDBSQL_ENGINE_INCLUDED
 #define MELINDA_MDBSQL_ENGINE_INCLUDED
 
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -12,7 +13,7 @@ namespace melinda::mdbsql
     class [[nodiscard]] engine final : public mblcxx::sops::noncopyable
     {
     public: // Construction
-        engine() = default;
+        engine(std::filesystem::path data_directory);
 
     public: // Destruction
         ~engine() = default;
@@ -21,6 +22,7 @@ namespace melinda::mdbsql
         bool execute(std::string_view query);
 
     private: // Data
+        std::filesystem::path data_directory_;
         std::vector<std::string> databases_;
     };
 } // namespace melinda::mdbsql

--- a/source/mdb/mdbsql/src/mdbsql_engine.cpp
+++ b/source/mdb/mdbsql/src/mdbsql_engine.cpp
@@ -5,6 +5,11 @@
 #include <mbltrc_trace.h>
 #include <mdbsql_grammar.h>
 
+melinda::mdbsql::engine::engine(std::filesystem::path data_directory)
+    : data_directory_ {std::move(data_directory)}
+{
+}
+
 bool melinda::mdbsql::engine::execute(std::string_view query)
 {
     std::optional<statement> parsed;

--- a/source/mdb/mdbsql/test/mdbsql.t.cpp
+++ b/source/mdb/mdbsql/test/mdbsql.t.cpp
@@ -1,0 +1,14 @@
+#include <mdbsql.t.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdlib.h>
+
+using namespace melinda;
+
+std::filesystem::path mdbsql::t::runtime_directory()
+{
+    char* const env = secure_getenv("MELINDA_TEST_DIRECTORY");
+    REQUIRE(env);
+    return {env};
+}

--- a/source/mdb/mdbsql/test/mdbsql.t.h
+++ b/source/mdb/mdbsql/test/mdbsql.t.h
@@ -1,0 +1,11 @@
+#ifndef MELINDA_MDBSQL_T_INCLUDED
+#define MELINDA_MDBSQL_T_INCLUDED
+
+#include <filesystem>
+
+namespace melinda::mdbsql::t
+{
+    std::filesystem::path runtime_directory();
+} // namespace melinda::mdbsql::t
+
+#endif

--- a/source/mdb/mdbsql/test/mdbsql_engine.t.cpp
+++ b/source/mdb/mdbsql/test/mdbsql_engine.t.cpp
@@ -2,17 +2,19 @@
 
 #include <mdbsql_engine.h>
 
+#include <mdbsql.t.h>
+
 using namespace melinda;
 
 TEST_CASE("Creating a database succeeds", "[exec]")
 {
-    mdbsql::engine engine;
+    mdbsql::engine engine {mdbsql::t::runtime_directory()};
     REQUIRE(engine.execute("CREATE DATABASE books;"));
 }
 
 TEST_CASE("Creating a already existing dabase fails", "[exec]")
 {
-    mdbsql::engine engine;
+    mdbsql::engine engine {mdbsql::t::runtime_directory()};
     REQUIRE(engine.execute("CREATE DATABASE books;"));
     REQUIRE_FALSE(engine.execute("CREATE DATABASE books;"));
 }

--- a/source/mdb/mdbsrv/CMakeLists.txt
+++ b/source/mdb/mdbsrv/CMakeLists.txt
@@ -3,8 +3,10 @@ include(${PROJECT_SOURCE_DIR}/cmake/Catch2.cmake)
 set(TARGET_NAME mdbsrv)
 
 add_executable(${TARGET_NAME}
+    src/mdbsrv_options.cpp
     src/mdbsrv.m.cpp)
 add_dependencies(${TARGET_NAME} clang-format)
+target_include_directories(${TARGET_NAME} PUBLIC include)
 target_link_libraries(${TARGET_NAME}
     PRIVATE
         cppzmq::cppzmq

--- a/source/mdb/mdbsrv/include/mdbsrv_options.h
+++ b/source/mdb/mdbsrv/include/mdbsrv_options.h
@@ -1,0 +1,17 @@
+#ifndef MELINDA_MDBSRV_OPTIONS_INCLUDED
+#define MELINDA_MDBSRV_OPTIONS_INCLUDED
+
+#include <filesystem>
+#include <optional>
+
+namespace melinda::mdbsrv
+{
+    struct [[nodiscard]] options
+    {
+        std::filesystem::path data_directory;
+    };
+
+    [[nodiscard]] std::optional<options> parse_options(int argc, char** argv);
+} // namespace melinda::mdbsrv
+
+#endif

--- a/source/mdb/mdbsrv/src/mdbsrv.m.cpp
+++ b/source/mdb/mdbsrv/src/mdbsrv.m.cpp
@@ -12,16 +12,26 @@
 #include <mdbnet_serialization.h>
 #include <mdbnet_server.h>
 
-int main()
+#include <mdbsrv_options.h>
+
+int main(int argc, char** argv)
 {
-    melinda::mbltrc::trace_options trace_config(std::filesystem::path("../log"),
+    std::optional<melinda::mdbsrv::options> const options {
+        melinda::mdbsrv::parse_options(argc, argv)};
+    if (!options)
+    {
+        return EXIT_FAILURE;
+    }
+
+    melinda::mbltrc::trace_options trace_config(
+        std::filesystem::path(options->data_directory),
         std::filesystem::path("server"));
     trace_config.level = melinda::mbltrc::trace_level::info;
 
     melinda::mbltrc::initialize_process_trace_handle(
         melinda::mbltrc::create_trace_handle(trace_config));
 
-    melinda::mdbsql::engine engine;
+    melinda::mdbsql::engine engine {options->data_directory};
 
     zmq::context_t ctx;
     constexpr char const* const address = "tcp://*:22365";

--- a/source/mdb/mdbsrv/src/mdbsrv_options.cpp
+++ b/source/mdb/mdbsrv/src/mdbsrv_options.cpp
@@ -1,0 +1,46 @@
+#include <mdbsrv_options.h>
+
+#include <iostream>
+
+#include <boost/program_options.hpp>
+
+std::optional<melinda::mdbsrv::options> melinda::mdbsrv::parse_options(int argc,
+    char** argv)
+{
+    namespace bpo = boost::program_options;
+
+    // https://stackoverflow.com/a/14940678
+    try
+    {
+        bpo::options_description cmd_options {"Allowed options"};
+        cmd_options.add_options()("help", "produce help message")(
+            "data-directory,D",
+            bpo::value<std::string>()->required(),
+            "data directory of the database server");
+
+        bpo::variables_map vm;
+        bpo::store(bpo::parse_command_line(argc, argv, cmd_options), vm);
+
+        if (vm.count("help"))
+        {
+            std::cout << cmd_options << '\n';
+            return std::nullopt;
+        }
+
+        bpo::notify(vm);
+
+        std::filesystem::path data_directory;
+        if (vm.count("data-directory"))
+        {
+            data_directory = vm["data-directory"].as<std::string>();
+        }
+
+        return {{std::move(data_directory)}};
+    }
+    catch (const bpo::error& ex)
+    {
+        std::cerr << "Failed start with given command line arguments: "
+                  << ex.what() << '\n';
+        return std::nullopt;
+    }
+}


### PR DESCRIPTION
- mdbsrv requires --data-directory,-d option to specify location of data storage
- Extend testing infrastructure with MELINDA_TEST_DIRECTORY environment variable to specify base directory used for tests